### PR TITLE
Add tables loop to document's `Paragraphs` func

### DIFF
--- a/document/document.go
+++ b/document/document.go
@@ -430,7 +430,7 @@ func (d *Document) StructuredDocumentTags() []StructuredDocumentTag {
 	return ret
 }
 
-// Paragraphs returns all of the paragraphs in the document body.
+// Paragraphs returns all of the paragraphs in the document body including tables.
 func (d *Document) Paragraphs() []Paragraph {
 	ret := []Paragraph{}
 	if d.x.Body == nil {
@@ -440,6 +440,14 @@ func (d *Document) Paragraphs() []Paragraph {
 		for _, c := range ble.EG_ContentBlockContent {
 			for _, p := range c.P {
 				ret = append(ret, Paragraph{d, p})
+			}
+		}
+	}
+
+	for _, t := range d.Tables() {
+		for _, r := range t.Rows() {
+			for _, c := range r.Cells() {
+				ret = append(ret, c.Paragraphs()...)
 			}
 		}
 	}


### PR DESCRIPTION
While fetching the paragraphs from the doc tables were totally ignored. 

Fixes #237, #267

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidoc/unioffice/280)
<!-- Reviewable:end -->
