### PR TITLE
Merge tables

### DIFF
--- a/document/document.go
+++ b/document/document.go
@@ -1062,3 +1062,33 @@ func (d Document) Bookmarks() []Bookmark {
 	}
 	return ret
 }
+
+// RemoveTable removes a table from a document.
+func (d *Document) RemoveTable(tbl Table) {
+	if d.x.Body == nil {
+		return
+	}
+
+	for _, ble := range d.x.Body.EG_BlockLevelElts {
+		for _, c := range ble.EG_ContentBlockContent {
+			for i, t := range c.Tbl {
+				// do we need to remove this paragraph
+				if t == tbl.x {
+					copy(c.Tbl[i:], c.Tbl[i+1:])
+					c.Tbl = c.Tbl[0 : len(c.Tbl)-1]
+					return
+				}
+			}
+
+			if c.Sdt != nil && c.Sdt.SdtContent != nil && c.Sdt.SdtContent.Tbl != nil {
+				for i, t := range c.Sdt.SdtContent.Tbl {
+					if t == tbl.x {
+						copy(c.Tbl[i:], c.Tbl[i+1:])
+						c.Tbl = c.Tbl[0 : len(c.Tbl)-1]
+						return
+					}
+				}
+			}
+		}
+	}
+}

--- a/document/table.go
+++ b/document/table.go
@@ -89,3 +89,13 @@ func (t Table) Rows() []Row {
 	}
 	return ret
 }
+
+// MergeWith merges table with another table to the bottom.
+func (t Table) MergeWith(t1 Table) {
+	for _, crc := range t1.x.EG_ContentRowContent {
+		t.x.EG_ContentRowContent = append(t.x.EG_ContentRowContent, crc)
+	}
+	for _, rme := range t1.x.EG_RangeMarkupElements {
+		t.x.EG_RangeMarkupElements = append(t.x.EG_RangeMarkupElements, rme)
+	}
+}


### PR DESCRIPTION
Merge example:

```
package main

import (
    "github.com/unidoc/unioffice/document"
)

func main() {
    doc, err := document.Open("tables.docx")
    if err != nil {
        panic(err)
    }

    tables := doc.Tables()
    t0, t1 := tables[0], tables[1]
    t0.MergeWith(t1) // now t0 became merged with t1
    doc.RemoveTable(t1) // remove table t1

    doc.SaveToFile("merged.docx")
}
```

or 

```
package main

import (
    "github.com/unidoc/unioffice/document"
)

func main() {
    doc, err := document.Open("tables.docx")
    if err != nil {
        panic(err)
    }

    doc.AddParagraph().AddRun().AddText("Merged table:")

    tables := doc.Tables()
    t := doc.AddTable() // create empty table
    for _, tbl := range tables { // iterate through all existing tables
        t.MergeWith(tbl) // merge new table with every existing one
    }

    doc.SaveToFile("merged.docx")
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidoc/unioffice/389)
<!-- Reviewable:end -->
