### PR TITLE
Add nil checks to prevent crashes [UO-26]

### DIFF
--- a/document/paragraphproperties.go
+++ b/document/paragraphproperties.go
@@ -370,7 +370,7 @@ func (p ParagraphProperties) Underline() wml.ST_Underline {
 func (p ParagraphProperties) UnderlineColor() string {
 	if underline := p.x.RPr.U; underline != nil {
 		color := underline.ColorAttr
-		if color.ST_HexColorRGB != nil {
+		if color != nil && color.ST_HexColorRGB != nil {
 			return *color.ST_HexColorRGB
 		}
 	}

--- a/document/runproperties.go
+++ b/document/runproperties.go
@@ -415,7 +415,7 @@ func (r RunProperties) Underline() wml.ST_Underline {
 func (r RunProperties) UnderlineColor() string {
 	if underline := r.x.U; underline != nil {
 		color := underline.ColorAttr
-		if color.ST_HexColorRGB != nil {
+		if color != nil && color.ST_HexColorRGB != nil {
 			return *color.ST_HexColorRGB
 		}
 	}


### PR DESCRIPTION
Fixes crashes that were found when loading paragraph data from a user document.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidoc/unioffice/397)
<!-- Reviewable:end -->
